### PR TITLE
Fix/interval of custom scheduling show wrong

### DIFF
--- a/answer_buttons.py
+++ b/answer_buttons.py
@@ -9,6 +9,7 @@ from anki.cards import Card
 from anki.hooks import wrap
 from aqt import gui_hooks, tr
 from aqt.reviewer import Reviewer
+from anki.scheduler.v3 import Scheduler as V3Scheduler
 
 from .config import config
 
@@ -71,10 +72,16 @@ def make_buttonless_ease_row(self: Reviewer, front: bool = False) -> str:
     def button_time(ease: int) -> str:
         """Returns html with button-time text for the specified Ease."""
 
+        if v3 := self._v3:
+            assert isinstance(self.mw.col.sched, V3Scheduler)
+            labels = self.mw.col.sched.describe_next_states(v3.states)
+        else:
+            labels = None
+
         # Get button time from the default function,
         # but remove `class="nobold"` since it introduces `position: absolute`
         # which prevents the text from being visible when there is no button.
-        html = self._buttonTime(ease).replace('class="nobold"', '')
+        html = self._buttonTime(ease, v3_labels=labels).replace('class="nobold"', '')
         if config['color_buttons'] is True:
             html = html.replace('<span', f'<span style="color: {config.get_color(ease, self._defaultEase())};"', )
         return html


### PR DESCRIPTION
It is a problem similar to https://github.com/noobj2/Anki-Advanced-Review-Bottombar/pull/45

The interval displayed is inconsistent with the interval given by custom scheduling. 

![image](https://user-images.githubusercontent.com/32575846/218438830-2fbc7b33-3db9-46c0-95f0-d135de7a83a4.png)

I have attempted to fix it. This commit could let the interval show correctly after rating. But the interval displayed before rating is still incorrect.